### PR TITLE
Removed Specific Versions, so Entity Framework Mapping can be a diffe…

### DIFF
--- a/src/EntityFramework.BulkInsert/EntityFramework.BulkInsert.csproj
+++ b/src/EntityFramework.BulkInsert/EntityFramework.BulkInsert.csproj
@@ -61,9 +61,12 @@
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
-    <Reference Include="EntityFramework.MappingAPI, Version=6.1.0.9, Culture=neutral, processorArchitecture=MSIL" />
+    <Reference Include="EntityFramework.MappingAPI, Version=6.1.0.9, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />


### PR DESCRIPTION
Removed the hard version reference so people with alternate nuget packages don't run into version issues.  Also, it seems like the EntityFramework.MappingAPI nuget packages now have no code in them, and are pushing people towards buying an alternate library. That is disappointing. This fixed our assembly reference issues.