### PR TITLE
Updated dependencies for MySQL and SQL Server CE NuGet packages

### DIFF
--- a/build/EntityFramework.BulkInsert.MySql.nuspec
+++ b/build/EntityFramework.BulkInsert.MySql.nuspec
@@ -23,7 +23,7 @@
     <tags>data ef ef6 code-first batch bulk insert mysql</tags>
     <dependencies>
       <dependency id="EntityFramework" version="6.1.0" />    
-      <dependency id="EntityFramework.BulkInsert" version="6.0.3.9" />
+      <dependency id="EntityFramework6.BulkInsert" version="6.0.3.9" />
       <dependency id="MySql.Data" version="6.9.11" />
       <dependency id="MySql.Data.Entity" version="6.9.11" />
     </dependencies>

--- a/build/EntityFramework.BulkInsert.SqlServerCe.nuspec
+++ b/build/EntityFramework.BulkInsert.SqlServerCe.nuspec
@@ -23,7 +23,7 @@
     <tags>data ef ef6 code-first batch bulk insert</tags>
     <dependencies>
       <dependency id="EntityFramework" version="6.1.0" />
-      <dependency id="EntityFramework.BulkInsert" version="6.0.3.9" />
+      <dependency id="EntityFramework6.BulkInsert" version="6.0.3.9" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Currently, the latest versions of the `EntityFramework6.BulkInsert.MySql` and `EntityFramework6.BulkInsert.SqlServerCe` NuGet packages cannot be installed from the master NuGet repository, because they reference an unlisted/deprecated package, `EntityFramework.BulkInsert`. To resolve this issue, the MySql and SQL Server CE package dependencies have been updated to reference the `EntityFramework6.BulkInsert` package instead.

After locally building the nupkg files for the MySQL and SQL Server CE packages with the updated dependencies, I was able to successfully install them in to a new project.